### PR TITLE
feat: store completions in `$XDG_CONFIG_HOME` instead of `$HOME`

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ It works on bash and zsh on Linux, macOS, and Windows.
 
 There are several ways to achieve shell completions for CLI commands. Most of them depend on which shell you are using and, in some cases, the terminal.
 
-The approach used by `cli_completion` is to create shell script files in a directory under the user's home ( `~/.dart-cli-completion`  for Linux/macOS users) and then source these scripts in the shell initialization files (`~/.zshrc`, for example). For Windows users, completion information is stored in local app data (typically something like `C:\Users\You\AppData\Local`). Currently, completion will only work from a bash shell on Windows.
+The approach used by `cli_completion` is to create shell script files in a directory under the user's home ( `$XDG_CONFIG_HOME/.dart-cli-completion` or `~/.dart-cli-completion`  for Linux/macOS users) and then source these scripts in the shell initialization files (`~/.zshrc`, for example). For Windows users, completion information is stored in local app data (typically something like `C:\Users\You\AppData\Local`). Currently, completion will only work from a bash shell on Windows.
 
 We call this process [installation](#the-installation-process).
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ It works on bash and zsh on Linux, macOS, and Windows.
 
 There are several ways to achieve shell completions for CLI commands. Most of them depend on which shell you are using and, in some cases, the terminal.
 
-The approach used by `cli_completion` is to create shell script files in a directory under the user's home ( `$XDG_CONFIG_HOME/.dart-cli-completion` or `~/.dart-cli-completion`  for Linux/macOS users) and then source these scripts in the shell initialization files (`~/.zshrc`, for example). For Windows users, completion information is stored in local app data (typically something like `C:\Users\You\AppData\Local`). Currently, completion will only work from a bash shell on Windows.
+The approach used by `cli_completion` is to create shell script files in a directory under the user's home ( `$XDG_CONFIG_HOME/.dart-cli-completion` or `~/.dart-cli-completion` for Linux/macOS users) and then source these scripts in the shell initialization files (`~/.zshrc`, for example). For Windows users, completion information is stored in local app data (typically something like `C:\Users\You\AppData\Local`). Currently, completion will only work from a bash shell on Windows.
 
 We call this process [installation](#the-installation-process).
 

--- a/lib/src/installer/completion_installation.dart
+++ b/lib/src/installer/completion_installation.dart
@@ -72,7 +72,7 @@ class CompletionInstallation {
   /// %LOCALAPPDATA%/DartCLICompletion
   ///
   /// If [isWindows] is false, it will return the directory defined by
-  /// $HOME/.dart_cli_completion
+  /// $XDG_CONFIG_HOME/.dart_cli_completion or $HOME/.dart_cli_completion
   @visibleForTesting
   Directory get completionConfigDir {
     if (isWindows) {
@@ -80,9 +80,13 @@ class CompletionInstallation {
       final localAppData = environment['LOCALAPPDATA']!;
       return Directory(path.join(localAppData, 'DartCLICompletion'));
     } else {
-      // Use home on posix systems
-      final home = environment['HOME']!;
-      return Directory(path.join(home, '.dart-cli-completion'));
+      // Try using XDG config folder
+      var dirPath = environment['XDG_CONFIG_HOME'];
+      // Fallback to $HOME if not following XDG specification
+      if (dirPath == null || dirPath.isEmpty) {
+        dirPath = environment['HOME'];
+      }
+      return Directory(path.join(dirPath!, '.dart-cli-completion'));
     }
   }
 

--- a/test/src/installer/completion_installation_test.dart
+++ b/test/src/installer/completion_installation_test.dart
@@ -73,20 +73,38 @@ void main() {
         );
       });
 
-      test('gets config dir location on posix', () {
-        final installation = CompletionInstallation(
-          configuration: zshConfiguration,
-          logger: logger,
-          isWindows: false,
-          environment: {
-            'HOME': tempDir.path,
-          },
-        );
+      group('gets config dir location on posix ()', () {
+        test('respects XDG home', () {
+          final installation = CompletionInstallation(
+            configuration: zshConfiguration,
+            logger: logger,
+            isWindows: false,
+            environment: {
+              'XDG_CONFIG_HOME': tempDir.path,
+              'HOME': 'ooohnoooo',
+            },
+          );
 
-        expect(
-          installation.completionConfigDir.path,
-          path.join(tempDir.path, '.dart-cli-completion'),
-        );
+          expect(
+            installation.completionConfigDir.path,
+            path.join(tempDir.path, '.dart-cli-completion'),
+          );
+        });
+        test('defaults to home', () {
+          final installation = CompletionInstallation(
+            configuration: zshConfiguration,
+            logger: logger,
+            isWindows: false,
+            environment: {
+              'HOME': tempDir.path,
+            },
+          );
+
+          expect(
+            installation.completionConfigDir.path,
+            path.join(tempDir.path, '.dart-cli-completion'),
+          );
+        });
       });
     });
 

--- a/test/src/installer/completion_installation_test.dart
+++ b/test/src/installer/completion_installation_test.dart
@@ -90,6 +90,7 @@ void main() {
             path.join(tempDir.path, '.dart-cli-completion'),
           );
         });
+
         test('defaults to home', () {
           final installation = CompletionInstallation(
             configuration: zshConfiguration,

--- a/test/src/installer/completion_installation_test.dart
+++ b/test/src/installer/completion_installation_test.dart
@@ -73,7 +73,7 @@ void main() {
         );
       });
 
-      group('gets config dir location on posix ()', () {
+      group('gets config dir location on posix', () {
         test('respects XDG home', () {
           final installation = CompletionInstallation(
             configuration: zshConfiguration,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**/IN DEVELOPMENT/HOLD

## Description

A lot of programs write their configuration files directly to their users' `$HOME`, making the output of `ls -la` an unmanageable mess.

[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#introduction) helps with keeping the home directory tidy by providing a convention that well-behaved programs can follow when deciding where to store certain types of files.

This PR introduces an attempt to add `dart-cli-completion/` to `$XDG_CONFIG_HOME` (if set) instead of the top-level home folder. On my machine it results in `~/.config/dart-cli-completion`. The behavior remains unchanged for users who have not explicitly set this variable (assuming that they don't care 🙂).

The XDG specification _should_ also be valid for Windows systems, but I'm not familiar enough with Windows to know whether it's a good idea to propagate this change there as well.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
  - although people currently using the tool will end up with two `dart-cli-completion` folders (they will have to delete the old one manually)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
