### PR TITLE
refactor: rename `Uninstalls` to `ShellCommandsMap`

### DIFF
--- a/lib/src/installer/completion_configuration.dart
+++ b/lib/src/installer/completion_configuration.dart
@@ -10,8 +10,7 @@ import 'package:meta/meta.dart';
 ///
 /// The map and its content are unmodifiable. This is to ensure that
 /// [CompletionConfiguration]s is fully immutable.
-// TODO(alestiago): Rename Uninstalls to ShellCommandsMap
-typedef Uninstalls
+typedef ShellCommandsMap
     = UnmodifiableMapView<SystemShell, UnmodifiableSetView<String>>;
 
 /// {@template completion_configuration}
@@ -29,8 +28,8 @@ class CompletionConfiguration {
   /// Creates an empty [CompletionConfiguration].
   @visibleForTesting
   CompletionConfiguration.empty()
-      : uninstalls = Uninstalls({}),
-        installs = Uninstalls({});
+      : uninstalls = ShellCommandsMap({}),
+        installs = ShellCommandsMap({});
 
   /// Creates a [CompletionConfiguration] from the given [file] content.
   ///
@@ -60,32 +59,34 @@ class CompletionConfiguration {
     }
 
     return CompletionConfiguration._(
-      uninstalls: _jsonDecodeUninstalls(
+      uninstalls: _jsonDecodeShellCommandsMap(
         decodedJson,
-        jsonKey: CompletionConfiguration._uninstallsJsonKey,
+        jsonKey: CompletionConfiguration.uninstallsJsonKey,
       ),
-      installs: _jsonDecodeUninstalls(
+      installs: _jsonDecodeShellCommandsMap(
         decodedJson,
-        jsonKey: CompletionConfiguration._installsJsonKey,
+        jsonKey: CompletionConfiguration.installsJsonKey,
       ),
     );
   }
 
   /// The JSON key for the [uninstalls] field.
-  static const String _uninstallsJsonKey = 'uninstalls';
+  @visibleForTesting
+  static const String uninstallsJsonKey = 'uninstalls';
 
   /// The JSON key for the [installs] field.
-  static const String _installsJsonKey = 'installs';
+  @visibleForTesting
+  static const String installsJsonKey = 'installs';
 
   /// Stores those commands that have been manually uninstalled by the user.
   ///
   /// Uninstalls are specific to a given [SystemShell].
-  final Uninstalls uninstalls;
+  final ShellCommandsMap uninstalls;
 
   /// Stores those commands that have completion installed.
   ///
   /// Installed commands are specific to a given [SystemShell].
-  final Uninstalls installs;
+  final ShellCommandsMap installs;
 
   /// Stores the [CompletionConfiguration] in the given [file].
   void writeTo(File file) {
@@ -98,16 +99,16 @@ class CompletionConfiguration {
   /// Returns a JSON representation of this [CompletionConfiguration].
   String _toJson() {
     return jsonEncode({
-      _uninstallsJsonKey: _jsonEncodeUninstalls(uninstalls),
-      _installsJsonKey: _jsonEncodeUninstalls(installs),
+      uninstallsJsonKey: _jsonEncodeShellCommandsMap(uninstalls),
+      installsJsonKey: _jsonEncodeShellCommandsMap(installs),
     });
   }
 
   /// Returns a copy of this [CompletionConfiguration] with the given fields
   /// replaced.
   CompletionConfiguration copyWith({
-    Uninstalls? uninstalls,
-    Uninstalls? installs,
+    ShellCommandsMap? uninstalls,
+    ShellCommandsMap? installs,
   }) {
     return CompletionConfiguration._(
       uninstalls: uninstalls ?? this.uninstalls,
@@ -116,58 +117,59 @@ class CompletionConfiguration {
   }
 }
 
-/// Decodes [Uninstalls] from the given [json].
+/// Decodes [ShellCommandsMap] from the given [json].
 ///
 /// If the [json] is not partially or fully valid, it handles issues gracefully
 /// without throwing an [Exception].
-Uninstalls _jsonDecodeUninstalls(
+ShellCommandsMap _jsonDecodeShellCommandsMap(
   Map<String, dynamic> json, {
   required String jsonKey,
 }) {
   if (!json.containsKey(jsonKey)) {
-    return Uninstalls({});
+    return ShellCommandsMap({});
   }
-  final jsonUninstalls = json[jsonKey];
-  if (jsonUninstalls is! String) {
-    return Uninstalls({});
+  final jsonShellCommandsMap = json[jsonKey];
+  if (jsonShellCommandsMap is! String) {
+    return ShellCommandsMap({});
   }
-  late final Map<String, dynamic> decodedUninstalls;
+  late final Map<String, dynamic> decodedShellCommandsMap;
   try {
-    decodedUninstalls = jsonDecode(jsonUninstalls) as Map<String, dynamic>;
+    decodedShellCommandsMap =
+        jsonDecode(jsonShellCommandsMap) as Map<String, dynamic>;
   } on FormatException {
-    return Uninstalls({});
+    return ShellCommandsMap({});
   }
 
-  final newUninstalls = <SystemShell, UnmodifiableSetView<String>>{};
-  for (final entry in decodedUninstalls.entries) {
+  final newShellCommandsMap = <SystemShell, UnmodifiableSetView<String>>{};
+  for (final entry in decodedShellCommandsMap.entries) {
     final systemShell = SystemShell.tryParse(entry.key);
     if (systemShell == null) continue;
-    final uninstallSet = <String>{};
+    final commandsSet = <String>{};
     if (entry.value is List) {
       for (final uninstall in entry.value as List) {
         if (uninstall is String) {
-          uninstallSet.add(uninstall);
+          commandsSet.add(uninstall);
         }
       }
     }
-    newUninstalls[systemShell] = UnmodifiableSetView(uninstallSet);
+    newShellCommandsMap[systemShell] = UnmodifiableSetView(commandsSet);
   }
-  return UnmodifiableMapView(newUninstalls);
+  return UnmodifiableMapView(newShellCommandsMap);
 }
 
-/// Returns a JSON representation of the given [Uninstalls].
-String _jsonEncodeUninstalls(Uninstalls uninstalls) {
+/// Returns a JSON representation of the given [ShellCommandsMap].
+String _jsonEncodeShellCommandsMap(ShellCommandsMap shellCommandsMap) {
   return jsonEncode({
-    for (final entry in uninstalls.entries)
+    for (final entry in shellCommandsMap.entries)
       entry.key.toString(): entry.value.toList(),
   });
 }
 
-/// Provides convinience methods for [Uninstalls].
-extension UninstallsExtension on Uninstalls {
-  /// Returns a new [Uninstalls] with the given [command] added to
+/// Provides convinience methods for [ShellCommandsMap].
+extension ShellCommandsMapExtension on ShellCommandsMap {
+  /// Returns a new [ShellCommandsMap] with the given [command] added to
   /// [systemShell].
-  Uninstalls include({
+  ShellCommandsMap include({
     required String command,
     required SystemShell systemShell,
   }) {
@@ -184,9 +186,9 @@ extension UninstallsExtension on Uninstalls {
     );
   }
 
-  /// Returns a new [Uninstalls] with the given [command] removed from
+  /// Returns a new [ShellCommandsMap] with the given [command] removed from
   /// [systemShell].
-  Uninstalls exclude({
+  ShellCommandsMap exclude({
     required String command,
     required SystemShell systemShell,
   }) {

--- a/test/src/command_runner/completion_command_runner_test.dart
+++ b/test/src/command_runner/completion_command_runner_test.dart
@@ -171,7 +171,7 @@ void main() {
         final completioninstallationFilePath =
             path.join(tempDirectory.path, 'test-config.json');
         final completionInstallationFile = File(completioninstallationFilePath);
-        final uninstalls = Uninstalls({
+        final uninstalls = ShellCommandsMap({
           commandRunner.systemShell!:
               UnmodifiableSetView<String>({commandRunner.executableName}),
         });
@@ -209,7 +209,7 @@ void main() {
         final completioninstallationFilePath =
             path.join(tempDirectory.path, 'test-config.json');
         final completionInstallationFile = File(completioninstallationFilePath);
-        final installs = Uninstalls({
+        final installs = ShellCommandsMap({
           commandRunner.systemShell!:
               UnmodifiableSetView<String>({commandRunner.executableName}),
         });

--- a/test/src/installer/completion_configuration_test.dart
+++ b/test/src/installer/completion_configuration_test.dart
@@ -9,13 +9,16 @@ import 'package:test/test.dart';
 
 void main() {
   group('$CompletionConfiguration', () {
-    final testUninstalls = UnmodifiableMapView({
+    final testInstalls = ShellCommandsMap({
+      SystemShell.bash: UnmodifiableSetView({'very_good'}),
+    });
+    final testUninstalls = ShellCommandsMap({
       SystemShell.bash: UnmodifiableSetView({'very_bad'}),
     });
 
     group('fromFile', () {
       test(
-        'returns empty cache when file does not exist',
+        'returns empty $CompletionConfiguration when file does not exist',
         () {
           final tempDirectory = Directory.systemTemp.createTempSync();
           addTearDown(() => tempDirectory.deleteSync(recursive: true));
@@ -27,25 +30,26 @@ void main() {
             reason: 'File should not exist',
           );
 
-          final cache = CompletionConfiguration.fromFile(file);
+          final completionConfiguration =
+              CompletionConfiguration.fromFile(file);
           expect(
-            cache.uninstalls,
+            completionConfiguration.uninstalls,
             isEmpty,
             reason: 'Uninstalls should be initially empty',
           );
         },
       );
 
-      test('returns empty cache when file is empty', () {
+      test('returns empty $CompletionConfiguration when file is empty', () {
         final tempDirectory = Directory.systemTemp.createTempSync();
         addTearDown(() => tempDirectory.deleteSync(recursive: true));
 
         final file = File(path.join(tempDirectory.path, 'config.json'))
           ..writeAsStringSync('');
 
-        final cache = CompletionConfiguration.fromFile(file);
+        final completionConfiguration = CompletionConfiguration.fromFile(file);
         expect(
-          cache.uninstalls,
+          completionConfiguration.uninstalls,
           isEmpty,
           reason: 'Uninstalls should be initially empty',
         );
@@ -57,31 +61,40 @@ void main() {
         addTearDown(() => tempDirectory.deleteSync(recursive: true));
 
         final file = File(path.join(tempDirectory.path, 'config.json'));
-        final cache = CompletionConfiguration.empty().copyWith(
+        final completionConfiguration =
+            CompletionConfiguration.empty().copyWith(
+          installs: testInstalls,
           uninstalls: testUninstalls,
         )..writeTo(file);
 
-        final newCache = CompletionConfiguration.fromFile(file);
+        final newConfiguration = CompletionConfiguration.fromFile(file);
         expect(
-          newCache.uninstalls,
-          cache.uninstalls,
+          newConfiguration.installs,
+          equals(completionConfiguration.installs),
+          reason: 'Installs should match those defined in the file',
+        );
+        expect(
+          newConfiguration.uninstalls,
+          equals(completionConfiguration.uninstalls),
           reason: 'Uninstalls should match those defined in the file',
         );
       });
 
       test(
-        '''returns a $CompletionConfiguration with empty uninstalls if the file's JSON "uninstalls" key has a string value''',
+        '''returns a $CompletionConfiguration with empty uninstalls if the file's JSON uninstalls key has a string value''',
         () {
           final tempDirectory = Directory.systemTemp.createTempSync();
           addTearDown(() => tempDirectory.deleteSync(recursive: true));
 
-          const json = '{"uninstalls": "very_bad"}';
+          const json =
+              '{"${CompletionConfiguration.uninstallsJsonKey}": "very_bad"}';
           final file = File(path.join(tempDirectory.path, 'config.json'))
             ..writeAsStringSync(json);
 
-          final cache = CompletionConfiguration.fromFile(file);
+          final completionConfiguration =
+              CompletionConfiguration.fromFile(file);
           expect(
-            cache.uninstalls,
+            completionConfiguration.uninstalls,
             isEmpty,
             reason:
                 '''Uninstalls should be empty when the value is of an invalid type''',
@@ -90,21 +103,65 @@ void main() {
       );
 
       test(
-        '''returns a $CompletionConfiguration with empty uninstalls if file's JSON "uninstalls" key has a numeric value''',
+        '''returns a $CompletionConfiguration with empty installs if the file's JSON installs key has a string value''',
         () {
           final tempDirectory = Directory.systemTemp.createTempSync();
           addTearDown(() => tempDirectory.deleteSync(recursive: true));
 
-          const json = '{"uninstalls": 1}';
+          const json =
+              '{"${CompletionConfiguration.installsJsonKey}": "very_bad"}';
           final file = File(path.join(tempDirectory.path, 'config.json'))
             ..writeAsStringSync(json);
 
-          final cache = CompletionConfiguration.fromFile(file);
+          final completionConfiguration =
+              CompletionConfiguration.fromFile(file);
           expect(
-            cache.uninstalls,
+            completionConfiguration.installs,
+            isEmpty,
+            reason:
+                '''Installs should be empty when the value is of an invalid type''',
+          );
+        },
+      );
+
+      test(
+        '''returns a $CompletionConfiguration with empty uninstalls if file's JSON uninstalls key has a numeric value''',
+        () {
+          final tempDirectory = Directory.systemTemp.createTempSync();
+          addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+          const json = '{"${CompletionConfiguration.uninstallsJsonKey}": 1}';
+          final file = File(path.join(tempDirectory.path, 'config.json'))
+            ..writeAsStringSync(json);
+
+          final completionConfiguration =
+              CompletionConfiguration.fromFile(file);
+          expect(
+            completionConfiguration.uninstalls,
             isEmpty,
             reason:
                 '''Uninstalls should be empty when the value is of an invalid type''',
+          );
+        },
+      );
+
+      test(
+        '''returns a $CompletionConfiguration with empty installs if file's JSON installs key has a numeric value''',
+        () {
+          final tempDirectory = Directory.systemTemp.createTempSync();
+          addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+          const json = '{"${CompletionConfiguration.installsJsonKey}": 1}';
+          final file = File(path.join(tempDirectory.path, 'config.json'))
+            ..writeAsStringSync(json);
+
+          final completionConfiguration =
+              CompletionConfiguration.fromFile(file);
+          expect(
+            completionConfiguration.installs,
+            isEmpty,
+            reason:
+                '''Installs should be empty when the value is of an invalid type''',
           );
         },
       );
@@ -127,7 +184,7 @@ void main() {
         expect(
           file.existsSync(),
           isTrue,
-          reason: 'File should exist after cache creation',
+          reason: 'File should exist after completionConfiguration creation',
         );
       });
 
@@ -155,14 +212,22 @@ void main() {
         addTearDown(() => tempDirectory.deleteSync(recursive: true));
 
         final file = File(path.join(tempDirectory.path, 'config.json'));
-        final cache = CompletionConfiguration.empty().copyWith(
+        final completionConfiguration =
+            CompletionConfiguration.empty().copyWith(
+          installs: testInstalls,
           uninstalls: testUninstalls,
         )..writeTo(file);
 
-        final newCache = CompletionConfiguration.fromFile(file);
+        final newcompletionConfiguration =
+            CompletionConfiguration.fromFile(file);
         expect(
-          newCache.uninstalls,
-          cache.uninstalls,
+          newcompletionConfiguration.installs,
+          completionConfiguration.installs,
+          reason: 'Installs should match those defined in the file',
+        );
+        expect(
+          newcompletionConfiguration.uninstalls,
+          completionConfiguration.uninstalls,
           reason: 'Uninstalls should match those defined in the file',
         );
       });
@@ -170,82 +235,109 @@ void main() {
 
     group('copyWith', () {
       test('members remain unchanged when nothing is specified', () {
-        final cache = CompletionConfiguration.empty();
-        final newCache = cache.copyWith();
+        final completionConfiguration = CompletionConfiguration.empty();
+        final newcompletionConfiguration = completionConfiguration.copyWith();
 
         expect(
-          newCache.uninstalls,
-          cache.uninstalls,
+          newcompletionConfiguration.uninstalls,
+          completionConfiguration.uninstalls,
           reason: 'Uninstalls should remain unchanged',
         );
       });
 
       test('modifies uninstalls when specified', () {
-        final cache = CompletionConfiguration.empty();
+        final completionConfiguration = CompletionConfiguration.empty();
         final uninstalls = testUninstalls;
-        final newCache = cache.copyWith(uninstalls: uninstalls);
+        final newcompletionConfiguration =
+            completionConfiguration.copyWith(uninstalls: uninstalls);
 
         expect(
-          newCache.uninstalls,
+          newcompletionConfiguration.uninstalls,
           equals(uninstalls),
           reason: 'Uninstalls should be modified',
+        );
+      });
+
+      test('modifies installs when specified', () {
+        final completionConfiguration = CompletionConfiguration.empty();
+        final installs = testUninstalls;
+        final newcompletionConfiguration =
+            completionConfiguration.copyWith(installs: installs);
+
+        expect(
+          newcompletionConfiguration.uninstalls,
+          equals(installs),
+          reason: 'Installs should be modified',
         );
       });
     });
   });
 
-  group('UninstallsExtension', () {
+  group('ShellCommandsMapExtension', () {
     group('include', () {
-      test('adds command to $Uninstalls when not already in', () {
+      test('adds command to $ShellCommandsMap when not already in', () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({});
+        final shellCommandsMap = ShellCommandsMap({});
 
-        final newUninstalls =
-            uninstalls.include(command: testCommand, systemShell: testShell);
+        final newShellCommadsMap = shellCommandsMap.include(
+          command: testCommand,
+          systemShell: testShell,
+        );
 
         expect(
-          newUninstalls.contains(command: testCommand, systemShell: testShell),
+          newShellCommadsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isTrue,
         );
       });
 
-      test('does nothing when $Uninstalls already has command', () {
+      test('does nothing when $ShellCommandsMap already has command', () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({
+        final shellCommandsMap = ShellCommandsMap({
           testShell: UnmodifiableSetView({testCommand}),
         });
 
-        final newUninstalls =
-            uninstalls.include(command: testCommand, systemShell: testShell);
+        final newShellCommadsMap = shellCommandsMap.include(
+          command: testCommand,
+          systemShell: testShell,
+        );
 
         expect(
-          newUninstalls.contains(command: testCommand, systemShell: testShell),
+          newShellCommadsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isTrue,
         );
       });
 
-      test('adds command $Uninstalls when on a different shell', () {
+      test('adds command $ShellCommandsMap when on a different shell', () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({
+        final shellCommandsMap = ShellCommandsMap({
           testShell: UnmodifiableSetView({testCommand}),
         });
 
         const anotherShell = SystemShell.zsh;
-        final newUninstalls = uninstalls.include(
+        final newShellCommadsMap = shellCommandsMap.include(
           command: testCommand,
           systemShell: anotherShell,
         );
         expect(testShell, isNot(equals(anotherShell)));
 
         expect(
-          newUninstalls.contains(command: testCommand, systemShell: testShell),
+          newShellCommadsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isTrue,
         );
         expect(
-          newUninstalls.contains(
+          newShellCommadsMap.contains(
             command: testCommand,
             systemShell: anotherShell,
           ),
@@ -255,75 +347,96 @@ void main() {
     });
 
     group('exclude', () {
-      test('removes command when in $Uninstalls', () {
+      test('removes command when in $ShellCommandsMap', () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({
+        final shellCommandsMap = ShellCommandsMap({
           testShell: UnmodifiableSetView({testCommand}),
         });
 
-        final newUninstalls =
-            uninstalls.exclude(command: testCommand, systemShell: testShell);
+        final newShellCommandsMap = shellCommandsMap.exclude(
+          command: testCommand,
+          systemShell: testShell,
+        );
 
         expect(
-          newUninstalls.contains(command: testCommand, systemShell: testShell),
+          newShellCommandsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isFalse,
         );
       });
 
-      test('does nothing when command not in $Uninstalls', () {
+      test('does nothing when command not in $ShellCommandsMap', () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({});
+        final shellCommandsMap = ShellCommandsMap({});
 
-        final newUninstalls =
-            uninstalls.exclude(command: testCommand, systemShell: testShell);
+        final newShellCommandsMap = shellCommandsMap.exclude(
+          command: testCommand,
+          systemShell: testShell,
+        );
 
         expect(
-          newUninstalls.contains(command: testCommand, systemShell: testShell),
+          newShellCommandsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isFalse,
         );
       });
 
-      test('does nothing when command in $Uninstalls is on a different shell',
+      test(
+          '''does nothing when command in $ShellCommandsMap is on a different shell''',
           () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({
+        final shellCommandsMap = ShellCommandsMap({
           testShell: UnmodifiableSetView({testCommand}),
         });
 
         const anotherShell = SystemShell.zsh;
-        final newUninstalls =
-            uninstalls.exclude(command: testCommand, systemShell: anotherShell);
+        final newShellCommadsMap = shellCommandsMap.exclude(
+          command: testCommand,
+          systemShell: anotherShell,
+        );
 
         expect(
-          newUninstalls.contains(command: testCommand, systemShell: testShell),
+          newShellCommadsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isTrue,
         );
       });
     });
 
     group('contains', () {
-      test('returns true when command is in $Uninstalls for the given shell',
+      test(
+          '''returns true when command is in $ShellCommandsMap for the given shell''',
           () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({
+        final shellCommandsMap = ShellCommandsMap({
           testShell: UnmodifiableSetView({testCommand}),
         });
 
         expect(
-          uninstalls.contains(command: testCommand, systemShell: testShell),
+          shellCommandsMap.contains(
+            command: testCommand,
+            systemShell: testShell,
+          ),
           isTrue,
         );
       });
 
-      test('returns false when command is in $Uninstalls for another shell',
+      test(
+          '''returns false when command is in $ShellCommandsMap for another shell''',
           () {
         const testCommand = 'test_command';
         const testShell = SystemShell.bash;
-        final uninstalls = Uninstalls({
+        final shellCommandsMap = ShellCommandsMap({
           testShell: UnmodifiableSetView({testCommand}),
         });
 
@@ -331,7 +444,10 @@ void main() {
         expect(testShell, isNot(equals(anotherShell)));
 
         expect(
-          uninstalls.contains(command: testCommand, systemShell: anotherShell),
+          shellCommandsMap.contains(
+            command: testCommand,
+            systemShell: anotherShell,
+          ),
           isFalse,
         );
       });

--- a/test/src/installer/completion_installation_test.dart
+++ b/test/src/installer/completion_installation_test.dart
@@ -515,7 +515,7 @@ void main() {
         final completionConfigurationFile =
             installation.completionConfigurationFile;
 
-        final uninstalls = Uninstalls({
+        final uninstalls = ShellCommandsMap({
           systemShell: UnmodifiableSetView({command}),
         });
         CompletionConfiguration.empty()


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Changes, since #74 is making use of the `Uninstalls` logic, it makes sense to rename the type definition.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
