### PR TITLE
chore: tighten dependencies

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,14 +7,14 @@ environment:
   sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  args: ^2.3.1
+  args: ^2.5.0
   cli_completion:
     path: ../
-  mason_logger: ^0.2.2
+  mason_logger: ^0.2.16
 
 dev_dependencies:
-  mocktail: ^1.0.0
-  test: ^1.25.0
+  mocktail: ^1.0.4
+  test: ^1.25.8
   very_good_analysis: ^6.0.0
 
 executables:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,13 +4,13 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
+  sdk: ^3.5.0
 
 dependencies:
   args: ^2.5.0
   cli_completion:
     path: ../
-  mason_logger: ^0.2.16
+  mason_logger: ^0.3.0
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/lib/src/command_runner/completion_command_runner.dart
+++ b/lib/src/command_runner/completion_command_runner.dart
@@ -139,10 +139,8 @@ abstract class CompletionCommandRunner<T> extends CommandRunner<T> {
           completionLogger.info(
             '$suggestion${description != null ? ':$description' : ''}',
           );
-          break;
         case SystemShell.bash:
           completionLogger.info(entry.key);
-          break;
       }
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,20 +5,20 @@ repository: https://github.com/VeryGoodOpenSource/cli_completion
 issue_tracker: https://github.com/VeryGoodOpenSource/cli_completion/issues
 topics: [cli, completion, shell, bash, autocomplete]
 screenshots:
-  - description: 'This screenshot shows the completion of a dart CLI.'
+  - description: "This screenshot shows the completion of a dart CLI."
     path: doc/screen.png
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
+  sdk: ^3.5.0
 
 dependencies:
-  args: ^2.3.1
+  args: ^2.5.0
   equatable: ^2.0.5
-  mason_logger: ^0.2.2
-  meta: ^1.8.0
-  path: ^1.8.2
+  mason_logger: ^0.3.0
+  meta: ^1.15.0
+  path: ^1.9.0
 
 dev_dependencies:
-  mocktail: ^1.0.0
-  test: ^1.24.6
-  very_good_analysis: ">=5.1.0 <7.0.0"
+  mocktail: ^1.0.4
+  test: ^1.25.8
+  very_good_analysis: ^6.0.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

The recent `mason_logger` update tighten its dependencies including bumping the Dart SDK to 3.5.0, see https://github.com/felangel/mason/pull/1395.

Such update is blocking us on https://github.com/VeryGoodOpenSource/very_good_templates/pull/178.

We're tightening to Dart SDK 3.5.0 to support the latest `mason_logger` version, with such change we're also taking the opportunity to tighten the other dependencies (to be the latest).

Most changes generated by running and formatting:

```sh
 dart pub upgrade --tighten
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
